### PR TITLE
Fix Return Processing and Add Quick Test

### DIFF
--- a/lambda_functions/POSSubmitReturn.py
+++ b/lambda_functions/POSSubmitReturn.py
@@ -607,6 +607,8 @@ def execute_return_transaction(return_ticket_table, return_product_table, produc
             
             # Find matching order product record
             try:
+                # Scan may be paginated; collect all pages to ensure we find the record
+                order_products_list = []
                 response = order_product_table.scan(
                     FilterExpression='orderTicket_id = :order_id AND product_id = :product_id',
                     ExpressionAttributeValues={
@@ -614,8 +616,19 @@ def execute_return_transaction(return_ticket_table, return_product_table, produc
                         ':product_id': product_id
                     }
                 )
-                
-                order_products_list = response.get('Items', [])
+                order_products_list.extend(response.get('Items', []))
+
+                # Handle pagination
+                while 'LastEvaluatedKey' in response:
+                    response = order_product_table.scan(
+                        FilterExpression='orderTicket_id = :order_id AND product_id = :product_id',
+                        ExpressionAttributeValues={
+                            ':order_id': order_id,
+                            ':product_id': product_id
+                        },
+                        ExclusiveStartKey=response['LastEvaluatedKey']
+                    )
+                    order_products_list.extend(response.get('Items', []))
                 
                 # Find the matching product (considering variant)
                 for order_product in order_products_list:

--- a/lambda_functions/test_POSSubmitReturn_quick.py
+++ b/lambda_functions/test_POSSubmitReturn_quick.py
@@ -1,0 +1,46 @@
+import json
+import sys
+import os
+
+# Add the lambda_functions directory to the path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from POSSubmitReturn import lambda_handler
+
+# Quick test event for POST /returns
+test_event = {
+    'httpMethod': 'POST',
+    'path': '/returns',
+    'requestContext': {
+        'stage': 'PROD'
+    },
+    'headers': {
+        'Content-Type': 'application/json'
+    },
+    'body': json.dumps({
+        "order_id": "606e8de6-4ad0-43c2-b4a7-539309537599",
+        "cash_register_id": "18342745-f0da-40e6-bec0-5cc11324fa6e",
+        "products": [
+            {
+                "id": "4d6b859b-f84d-49ab-a828-a642710720d6",
+                "variant_id": "5d0a8fc5-03b1-4f06-bc5e-443aa6e5617c",
+                "quantity": 1
+            }
+        ],
+        "refund_method": "cash",
+        "notes": "Prueba",
+        "user_id": "3f418447-bbc3-4906-9c59-7a1c40efa35a"
+    })
+}
+
+print("Running quick test for POSSubmitReturn...")
+print(json.dumps(test_event, indent=2))
+
+result = lambda_handler(test_event, None)
+
+print("\nStatus Code:", result.get('statusCode'))
+try:
+    body = json.loads(result.get('body', '{}'))
+    print(json.dumps(body, indent=2))
+except Exception:
+    print(result.get('body'))


### PR DESCRIPTION
# Fix Return Processing and Add Quick Test

## Overview

This pull request addresses a bug in the return processing logic where not all order products were being considered due to unhandled pagination. It also introduces a new quick test for the `POSSubmitReturn` lambda function to facilitate faster testing cycles.

## Bug Fix

### Paginated Scan in `POSSubmitReturn.py`

- **Problem:** The `scan` operation on the `order_product_table` was not handling paginated results, leading to potential failures in finding the correct order product to process for a return if it wasn't in the first page of results.
- **Solution:** Implemented a `while` loop to continuously scan the table using the `LastEvaluatedKey` from the response until all pages have been processed, ensuring all order products are retrieved and considered.